### PR TITLE
Add jinja2 to requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+venv/
+
 __pycache__
 
 .*.swp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tornado
 psutil
+jinja2


### PR DESCRIPTION
With a clean virtualenv it needs to be explicitly installed, since it's not depended on by tornado or psutil.
